### PR TITLE
Upgrde to latest "tns-core-modules" and "nativescript-telerik-ui" 

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/tjvantoll/nativescript-template-drawer",
   "dependencies": {
     "nativescript-statusbar": "^1.0.0",
-    "nativescript-telerik-ui": "^1.3.1",
-    "tns-core-modules": "2.2.1"
+    "nativescript-telerik-ui": "1.4.1",
+    "tns-core-modules": "2.3.0"
   }
 }


### PR DESCRIPTION
Noticed that the template is currently not working and is throwing an error (complaining that it cannot find "utils.ios.getter"). This is due to mismatch versions of the nativescript-telerik-ui and tns-core-modules plugins.

Make sure not to use " ^ " for the nativescript-telerik-ui as it may cause an error since the nativescript-telerik-ui plugin uses functionalities from tns-core-modules plugin. You should either make sure both use the "latest major release" in the package.json or both use a specific version to avoid future mismatch of versions.
